### PR TITLE
Fetch upstream of future extensions

### DIFF
--- a/Source/SDFutureExtensions/Private/FutureExtensionTaskGraph.h
+++ b/Source/SDFutureExtensions/Private/FutureExtensionTaskGraph.h
@@ -508,8 +508,8 @@ namespace SD
 				TExpectedFutureContinuationQueuedWork::SharedPromiseRef Promise = TExpectedFutureQueuedWork<R>::GetSharedPromise();
 				if (!Promise->IsSet())
 				{
-					//We're running on a thread pool, so we can just wait on our previous future.
-					PrevFuture.Get();
+					// We're running on a thread pool, so we can just wait on our previous future.
+					PrevFuture.Wait();
 
 					if (auto PinnedObject = LifetimeMonitor.Pin())
 					{

--- a/Source/SDFutureExtensions/Public/ExpectedFuture.h
+++ b/Source/SDFutureExtensions/Public/ExpectedFuture.h
@@ -399,6 +399,14 @@ namespace SD
 			return PreviousPromise->GetExecutionDetails();
 		}
 
+		void Wait() const
+		{
+			if (PreviousPromise)
+			{
+				PreviousPromise->GetCompletionEvent()->Wait();
+			}
+		}
+
 	private:
 		TSharedPtr<TExpectedPromiseState<ResultType>, ESPMode::ThreadSafe> PreviousPromise;
 	};
@@ -538,6 +546,14 @@ namespace SD
 		{
 			check(IsValid());
 			return PreviousPromise->GetExecutionDetails();
+		}
+
+		void Wait() const
+		{
+			if (PreviousPromise)
+			{
+				PreviousPromise->GetCompletionEvent()->Wait();
+			}
 		}
 
 	private:

--- a/Source/SDFutureExtensions/Public/ExpectedFuture.h
+++ b/Source/SDFutureExtensions/Public/ExpectedFuture.h
@@ -232,19 +232,19 @@ namespace SD
 		};
 
 		template<typename T>
-		class TWeakRefType<T, typename std::enable_if<std::is_base_of<TSharedFromThis<T>, T>::value>::type> : TWeakPtr<T>
+		class TWeakRefType<T, typename std::enable_if<std::is_base_of<TSharedFromThis<T, ESPMode::NotThreadSafe>, T>::value>::type> : TWeakPtr<T, ESPMode::NotThreadSafe>
 		{
 		public:
-			explicit TWeakRefType(T* Obj) : TWeakPtr<T>(GetWeakPtr(Obj)) {}
-			static TWeakPtr<T> GetWeakPtr(T* Obj)
+			explicit TWeakRefType(T* Obj) : TWeakPtr<T, ESPMode::NotThreadSafe>(GetWeakPtr(Obj)) {}
+			static TWeakPtr<T, ESPMode::NotThreadSafe> GetWeakPtr(T* Obj)
 			{
 				if (Obj)
 				{
 					return Obj->AsShared();
 				}
-				return TWeakPtr<T>();
+				return TWeakPtr<T, ESPMode::NotThreadSafe>();
 			}
-			TSharedPtr<T> Pin() const { return TWeakPtr<T>::Pin(); }
+			TSharedPtr<T, ESPMode::NotThreadSafe> Pin() const { return TWeakPtr<T, ESPMode::NotThreadSafe>::Pin(); }
 		};
 
 		template<typename T>

--- a/Source/SDFutureExtensions/Public/ExpectedFuture.h
+++ b/Source/SDFutureExtensions/Public/ExpectedFuture.h
@@ -423,6 +423,8 @@ namespace SD
 		{
 		}
 
+		TExpectedPromise(const TExpectedPromise& Other) = default;
+		TExpectedPromise& operator=(const TExpectedPromise& Other) = default;
 		TExpectedPromise(TExpectedPromise&& Other) = default;
 		TExpectedPromise& operator=(TExpectedPromise&& Other) = default;
 
@@ -573,6 +575,8 @@ namespace SD
 		{
 		}
 
+		TExpectedPromise(const TExpectedPromise& Other) = default;
+		TExpectedPromise& operator=(const TExpectedPromise& Other) = default;
 		TExpectedPromise(TExpectedPromise&& Other) = default;
 		TExpectedPromise& operator=(TExpectedPromise&& Other) = default;
 

--- a/Source/Test/Private/ExecutionPolicy.spec.cpp
+++ b/Source/Test/Private/ExecutionPolicy.spec.cpp
@@ -116,7 +116,7 @@ void FFutureTestSpec_ExecutionPolicy::Define()
 		.Then([this, Done](SD::TExpected<ENamedThreads::Type> Expected)
 		{
 			TestTrue("Async function is completed", Expected.IsCompleted());
-			TestEqual("Execution thread", *Expected, ENamedThreads::AnyThread);
+			TestTrue("Executed on the thread pool", (*Expected & ENamedThreads::ThreadIndexMask) == ENamedThreads::AnyThread);
 			Done.Execute();
 		});
 	});
@@ -136,7 +136,7 @@ void FFutureTestSpec_ExecutionPolicy::Define()
 		.Then([this, Done](SD::TExpected<ENamedThreads::Type> Expected)
 		{
 			TestTrue("Async function is completed", Expected.IsCompleted());
-			TestEqual("Execution thread", *Expected, ENamedThreads::AnyThread);
+			TestTrue("Executed on the thread pool", (*Expected & ENamedThreads::ThreadIndexMask) == ENamedThreads::AnyThread);
 			Done.Execute();
 		});
 	});


### PR DESCRIPTION
To be able to copy promises into a lambda and set the value we need one of the latest commits of the splash damage future extensions repo.